### PR TITLE
fix hints position calculations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,6 +508,7 @@ dependencies = [
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "termios 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ serde = { version = "1.0", features = ["derive"] }
 toml = "0.4"
 once_cell = "0.1.8"
 clap = "2.32.0"
+unicode-width = "0.1.5"

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -5,6 +5,7 @@ use regex::Regex;
 use std::io;
 use std::os::unix::io::AsRawFd;
 
+use unicode_width::UnicodeWidthStr;
 use termios::{tcsetattr, Termios, ECHO, ICANON, TCSANOW};
 
 /// Screen represents the Pane of tmux
@@ -107,7 +108,7 @@ impl Screen {
             if line.is_empty() {
                 continue;
             }
-            offset += (line.len() - 1) / width;
+            offset += (UnicodeWidthStr::width(line) - 1) / width;
             for ma in matcher.find_iter(line) {
                 let start = ma.start();
                 let end = ma.end();
@@ -116,7 +117,8 @@ impl Screen {
 
                 let start_in_line = start / width;
 
-                let screen_x = start - width * start_in_line;
+                let char_width_offset = UnicodeWidthStr::width(&line[0..start]) - start;
+                let screen_x = char_width_offset + start - width * start_in_line;
                 let screen_y = y + start_in_line;
 
                 self.hints.push(Hint::new(text, screen_x, screen_y));

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -92,12 +92,8 @@ pub fn clear_buffer() {
 }
 
 pub fn clean_string(buffer: &str) -> String {
-    let rectrl = Regex::new(r"\x1b[^m]*m").unwrap();
-    let reunicode = Regex::new(r"[^\x00-\x7F]").unwrap();
-
-    reunicode
-        .replace_all(&rectrl.replace_all(buffer, ""), " ")
-        .to_string()
+    let rectrl = Regex::new(r"\x1b[^m]*m|\p{Format}").unwrap();
+    rectrl.replace_all(&buffer, "").to_string()
 }
 
 pub fn select_window(title: &str) {


### PR DESCRIPTION
uses a better cleanup regex that handle only formatting characters, and use UnicodeWidth to calculate the with of characters